### PR TITLE
Add support for passing Pillar data

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ salt.ready.then(() => {
 `function` defaults to "test.ping"  
 `arg` defaults to false, not sent  
 `kwarg` defaults to false, not sent  
-`client` defaults to "local"
+`client` defaults to "local"  
 `pillar` defaults to false, not sent  
 
 Returns a Promise that resolves an object containing a return array with the data directly from the API.

--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ salt.ready.then(() => {
 
 ### Run functions
 
-`salt.fun(target, function, arguments, keyword arguments, client)`
+`salt.fun(target, function, arguments, keyword arguments, client, pillar)`
 
 `target` defaults to "*"  
 `function` defaults to "test.ping"  
 `arg` defaults to false, not sent  
 `kwarg` defaults to false, not sent  
-`client` defaults to "local"  
+`client` defaults to "local"
+`pillar` defaults to false, not sent  
 
 Returns a Promise that resolves an object containing a return array with the data directly from the API.
 

--- a/salt.js
+++ b/salt.js
@@ -28,7 +28,7 @@ class Salt {
 		}).catch(e => console.error(e));
 	}
 
-	async fun(tgt="*", fun="test.ping", arg=false, kwarg=false, client="local") {
+	async fun(tgt="*", fun="test.ping", arg=false, kwarg=false, client="local", pillar=false) {
 		if(this.expire <= new Date() / 1000) {
 			this.init();
 			await this.ready;
@@ -36,12 +36,12 @@ class Salt {
 		let form = { tgt, fun, client }
 		if(arg) form.arg = arg;
 		if(kwarg) form.kwarg = kwarg;
+		if(pillar) form.pillar = pillar;
 		return request({
 			url: this.config.url,
 			method: "POST",
-			json: true,
+			json: form,
 			headers: {"X-Auth-Token": this.token},
-			form
 		});
 	}
 


### PR DESCRIPTION
The rest_cherrypy module support pillar data passed as a JSON object. This PR adds the ability to send pillar data to fun's that accept it.

Also updated the Request call to use the JSON property to send the data and set the JSON header in the same line (preferred method).

